### PR TITLE
Zope4 integration

### DIFF
--- a/Admin.py
+++ b/Admin.py
@@ -150,7 +150,7 @@ class PageAdminSupport:
 
         Called on every page view (set AUTO_UPGRADE=0 in Default.py to
         prevent this).  You could also call this on every page in your
-        wiki to do a batch upgrade. Affects bobobase_modification_time. If
+        wiki to do a batch upgrade. Affects last_modified. If
         you later downgrade zwiki, the upgraded pages may not work so
         well.
         """
@@ -195,10 +195,10 @@ class PageAdminSupport:
         # Pre-0.9.10, creation_time has been a string in custom format and
         # last_edit_time has been a DateTime. Now both are kept as
         # ISO 8601-format strings. Might not be strictly necessary to upgrade
-        # in all cases.. will cause a lot of bobobase_mod_time
+        # in all cases.. will cause a lot of last_modified
         # updates.. do it anyway.
         if not self.last_edit_time:
-            self.last_edit_time = self.bobobase_modification_time().ISO8601()
+            self.last_edit_time = DateTime(self.last_modified(self)).ISO8601()
             changed = 1
         elif type(self.last_edit_time) is not StringType:
             self.last_edit_time = self.last_edit_time.ISO8601()
@@ -293,7 +293,7 @@ class PageAdminSupport:
 
         if changed:
             # do a commit now so the current render will have the correct
-            # bobobase_modification_time for display (many headers/footers
+            # last_modified for display (many headers/footers
             # still show it)
             # XXX I don't think we need to dick around with commits any more
             #get_transaction().commit()

--- a/Views.py
+++ b/Views.py
@@ -90,6 +90,7 @@ import os
 
 from App.Common import rfc1123_date
 from AccessControl import getSecurityManager, ClassSecurityInfo, Unauthorized
+from DateTime import DateTime
 from OFS.Image import File
 from AccessControl.class_init import InitializeClass
 from App.Dialogs import MessageDialog
@@ -159,8 +160,8 @@ def loadFile(name,dir='skins/zwiki'):
                 data = f.read()
                 mtime = os.path.getmtime(filepath)
                 file = File(name,'',data)
-                # bug workaround: bobobase_modification_time will otherwise be current time
-                file.bobobase_modification_time = lambda:mtime
+                # bug workaround: last_modified will otherwise be current time
+                file.last_modified = lambda:mtime
                 return file
             except IOError:
                 return None
@@ -280,6 +281,7 @@ TEMPLATES = SKINS['zwiki'] # backwards compatibility
 MACROS = {} # a flat dictionary of all macros defined in all templates
 # need to initialise it for some backwards compatibility assignments at startup
 [MACROS.update(t.pt_macros()) for t in TEMPLATES.values() if isPageTemplate(t)]
+
 def getmacros(self):
     """
     Get a dictionary of all the page template macros in the skin. More precisely,
@@ -804,7 +806,7 @@ class SkinViews:
         form = self.getSkinTemplate('stylesheet',suffixes=['.css',''])
         if isFile(form):
             if self.handle_modified_headers(
-                last_mod=form.bobobase_modification_time(), REQUEST=REQUEST):
+                last_mod=DateTime(form.last_modified(form)), REQUEST=REQUEST):
                 return ''
             else:
                 return form.index_html(REQUEST,REQUEST.RESPONSE)

--- a/Views.py
+++ b/Views.py
@@ -281,7 +281,6 @@ TEMPLATES = SKINS['zwiki'] # backwards compatibility
 MACROS = {} # a flat dictionary of all macros defined in all templates
 # need to initialise it for some backwards compatibility assignments at startup
 [MACROS.update(t.pt_macros()) for t in TEMPLATES.values() if isPageTemplate(t)]
-
 def getmacros(self):
     """
     Get a dictionary of all the page template macros in the skin. More precisely,

--- a/Views.py
+++ b/Views.py
@@ -161,7 +161,7 @@ def loadFile(name,dir='skins/zwiki'):
                 mtime = os.path.getmtime(filepath)
                 file = File(name,'',data)
                 # bug workaround: last_modified will otherwise be current time
-                file.last_modified = lambda:mtime
+                file.last_modified = lambda x: mtime
                 return file
             except IOError:
                 return None

--- a/ZWikiPage.py
+++ b/ZWikiPage.py
@@ -443,13 +443,13 @@ class ZWikiPage(
             if getattr(self, ignore_property, False): return False
         if last_mod == None:
             try:
-                # bobobase_modification_time reflects also changes
+                # modification time reflects also changes
                 # to voting, not like last_edit_time
-                last_mod = self.bobobase_modification_time()
+                last_mod = DateTime(self.last_modified(self))
             except DateTimeSyntaxError:
                 # if anything goes wrong with the stored date, we just
                 # ignore all 304 handling and go on as if nothing happened
-                BLATHER("invalid bobobase_modification time in page %s" \
+                BLATHER("invalid modification time in page %s" \
                             % (self.id()))
                 return False
         try: # we could have been fed an illegal date string


### PR DESCRIPTION
Dear wlang42,

I checked the lambda expression.
Due to the fact that last_modified needs an argument passed to it (see:  Zope-<version>/OFS/ObjectManager.py last_modified() ) 
I will pass a "mocking" argument to the lambda function which will be ignored. 

In Zope2.13 the call of the `bobobase_modification_time` in Views.py  `loadFile` will return mtime (epoch).
See commit:  f20dc0a14e0f4584ba547d5960df6bd850544904

Greetings
gelbi
