### PR TITLE
self.getPhysicalRoot().Control_Panel does not exist in Zope4

### DIFF
--- a/ZWikiPage.py
+++ b/ZWikiPage.py
@@ -1273,7 +1273,7 @@ class ZWikiPage(
         name utf-8-encoded.
         """
         return (self.pageWithId(self.canonicalIdFrom(name),url_quoted) or
-                self.pageWithId(self.canonicalIdFrom(self.toencoded(name,'utf-8')),url_quoted))
+                self.pageWithId(self.canonicalIdFrom(name and self.toencoded(name,'utf-8')),url_quoted))
 
     security.declareProtected(Permissions.View, 'pageWithNameOrId')
     def pageWithNameOrId(self,name,url_quoted=0):

--- a/__init__.py
+++ b/__init__.py
@@ -87,10 +87,8 @@ def initialize(context):
                 manage_addWikiForm,
                 manage_addWiki,
                 listWikis,
-                listZodbWikis,
                 listFsWikis,
                 addWikiFromFs,
-                addWikiFromZodb,
                 )
             )
         initializeForCMF(context)
@@ -277,8 +275,6 @@ def manage_addWiki(self, new_id, new_title='', wiki_type='basic',
     else:
         if wiki_type in self.listFsWikis():
             self.addWikiFromFs(new_id,new_title,wiki_type,REQUEST)
-        elif wiki_type in self.listZodbWikis():
-            self.addWikiFromZodb(new_id,new_title,wiki_type,REQUEST)
         else:
             if REQUEST:
                 return MessageDialog(
@@ -304,23 +300,6 @@ def manage_addWiki(self, new_id, new_title='', wiki_type='basic',
                 REQUEST.RESPONSE.redirect(u+'/manage_main?update_menu=1')
         else: # we're called programmatically through xx.manage_addProduct...
             return new_id
-
-def addWikiFromZodb(self,new_id, new_title='', wiki_type='basic',
-                        REQUEST=None):
-    """
-    Create a new zwiki web by cloning the specified template
-    in /Control_Panel/Products/ZWiki
-    """
-    # locate the specified wiki prototype
-    # these are installed in /Control_Panel/Products/ZWiki
-    prototype = self.getPhysicalRoot().Control_Panel.Products.ZWiki[wiki_type]
-
-    # clone it
-    self.manage_clone(prototype, new_id, REQUEST)
-    wiki = getattr(self, new_id)
-    wiki.manage_changeProperties(title=new_title)
-    # could do stuff with ownership here
-    # set it to low-privileged "nobody" by default ?
 
 def createFilesFromFsFolder(self, f, dir):
     """
@@ -424,21 +403,11 @@ def addZWikiPage(self, id, title='',
 
 def listWikis(self):
     """
-    list all wiki templates available in the filesystem or zodb
+    list all wiki templates sorted (only from fs)
     """
     wikis = self.listFsWikis()
-    for w in self.listZodbWikis():
-        if not w in wikis: wikis.append(w)
     wikis.sort()
     return wikis
-
-def listZodbWikis(self):
-    """
-    list the wiki templates available in the ZODB
-    """
-    list = self.getPhysicalRoot().Control_Panel.Products.ZWiki.objectIds()
-    list.remove('Help')
-    return list
 
 def listFsWikis(self):
     """

--- a/plugins/pagetypes/rst.py
+++ b/plugins/pagetypes/rst.py
@@ -308,6 +308,9 @@ def HTML(src,
     warnings = ''.join(warning_stream.messages)
 
     if output_encoding != 'unicode':
-        return output.encode(output_encoding)
+        try:
+            return output.encode(output_encoding)
+        except UnicodeEncodeError:
+            return output.encode('utf-8')
     else:
         return output

--- a/plugins/pagetypes/rst.py
+++ b/plugins/pagetypes/rst.py
@@ -172,7 +172,9 @@ ZwikiRstPageType = PageTypeRst
 # procedure and make it work now by hook or by crook.  The following
 # is based on ZPL-licensed code from lib/python/reStructuredText/__init__.py.
 
-from reStructuredText import sys, getConfiguration, publish_parts, Warnings
+import sys
+from App.config import getConfiguration
+from docutils.core import publish_parts
 
 # get encoding
 default_enc = sys.getdefaultencoding()
@@ -187,6 +189,14 @@ initial_header_level = getConfiguration().rest_header_level or default_level
 # elements
 default_lang = 'en'
 default_language_code = getConfiguration().rest_language_code or default_language
+
+class Warnings:
+
+    def __init__(self):
+        self.messages = []
+
+    def write(self, message):
+        self.messages.append(message)
 
 def render(src,
            writer='html4css1',

--- a/plugins/tinymce.py
+++ b/plugins/tinymce.py
@@ -20,7 +20,12 @@ class TinyMCESupport:
     security.declareProtected(Permissions.View, 'tinyMCEInstalled')
     def tinyMCEInstalled(self):
         """Is TinyMCE installed and configured?"""
-        installed = 'ZTinyMCE' in self.Control_Panel.Products.objectIds()
+        #temporary fix for Zope4 where self.Control_Panel.Products
+        #does not exists
+        try:
+            installed = 'ZTinyMCE' in self.Control_Panel.Products.objectIds()
+        except AttributeError:
+            installed = None
         return installed and getattr(self, 'tinymce.conf', None) is not None
 
     security.declareProtected(Permissions.View, 'supportsTinyMCE')

--- a/skins/zwiki/contentspage.pt
+++ b/skins/zwiki/contentspage.pt
@@ -1,5 +1,10 @@
+<!--<html metal:use-macro="here/main_template/macros/master" i18n:domain="zwiki"
+  tal:define="title python:container.title and gettext('Wiki contents for')+' '+container.title or gettext('Wiki contents')
+# XXX splicing translated and dynamic text - how to pass title in to fill-slot ?
+# XXX for now, complicated spans
+">-->
 <html metal:use-macro="here/main_template/macros/master" i18n:domain="zwiki"
-      tal:define="title python:container.title and gettext('Wiki contents for')+' '+container.title or gettext('Wiki contents')
+  tal:define="title python:container.title
 # XXX splicing translated and dynamic text - how to pass title in to fill-slot ?
 # XXX for now, complicated spans
 ">


### PR DESCRIPTION

Control_Panel Folder (:= self.getPhysicalRoot().Control_Panel) in ZODB does not exist anymore. Therefore, I removed the ability to get wiki templates from ZODB. Only FS wiki templates should be used from now.